### PR TITLE
Add global middleware to router

### DIFF
--- a/src/espresso/espresso.gleam
+++ b/src/espresso/espresso.gleam
@@ -16,7 +16,7 @@ pub fn get_port() -> Int {
 pub external fn exit(i32) -> Nil =
   "Elixir.Process" "exit/1"
 
-pub fn start(r: Router) {
+pub fn start(r: Router(req, res)) {
   let port = get_port()
   case cowboy.start(fn(request) { handle(r, request) }, on_port: port) {
     Ok(_) -> process.sleep_forever()

--- a/src/main.gleam
+++ b/src/main.gleam
@@ -24,7 +24,7 @@ pub fn main() {
     )
 
   let router =
-    router.new()
+    router.new(router.passthrough_middleware())
     |> get("/", fn(_req: Request(BitString)) { send(202, "Main Route") })
     |> get(
       "/cats",


### PR DESCRIPTION
You can pass a middleware function to the Router and it can change the types that your handlers can expect for the request or return for the response.