### PR TITLE
Add websockets support

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "espresso"
-version = "0.0.5"
+version = "0.0.6"
 description = "A simple gleam http server and router built on top of erlang cowboy"
 
 # Fill out these fields if you intend to generate HTML documentation or publish

--- a/src/cowboy/cowboy.gleam
+++ b/src/cowboy/cowboy.gleam
@@ -9,6 +9,7 @@ import espresso/request.{Params, Request}
 import espresso/response
 import espresso/service.{Service}
 import espresso/static.{Static}
+import espresso/websocket.{Websocket}
 import gleam/dynamic.{Dynamic}
 import gleam/erlang/atom
 import gleam/erlang/process.{Pid}
@@ -35,6 +36,7 @@ pub type Route(req, assigns, res) {
   ServiceRoute(Service(req, assigns, res))
   RouterRoute(Routes(req, assigns, res))
   StaticRoute(String, Static)
+  WebsocketRoute(Websocket)
 }
 
 /// Routes are the mapping between a path and the route. 
@@ -46,6 +48,8 @@ external type ModuleName
 
 external type CowboyStatic
 
+external type WebsocketModule
+
 external fn erlang_module_name() -> ModuleName =
   "gleam_cowboy_native" "module_name"
 
@@ -54,6 +58,9 @@ external fn erlang_router(CowboyRoutes) -> CowboyRouter =
 
 external fn erlang_cowboy_static() -> CowboyStatic =
   "gleam_cowboy_native" "static_module"
+
+external fn erlang_cowboy_websocket() -> WebsocketModule =
+  "gleam_websocket_native" "module_name"
 
 /// Takes a list of route structures and compiles them into a cowboy router.
 /// 
@@ -79,6 +86,11 @@ pub fn router(routes: Routes(req, assigns, res)) -> CowboyRouter {
           dynamic.from(path),
           dynamic.from(erlang_cowboy_static()),
           dynamic.from(config),
+        )
+        WebsocketRoute(service) -> #(
+          dynamic.from(path),
+          dynamic.from(erlang_cowboy_websocket()),
+          dynamic.from(service),
         )
       }
     })

--- a/src/espresso/websocket.gleam
+++ b/src/espresso/websocket.gleam
@@ -1,0 +1,25 @@
+//// Types used for interacting with cowboy websockets
+//// 
+//// https://ninenines.eu/docs/en/cowboy/2.6/manual/cowboy_websocket/
+
+/// Frames represent four common types of responses
+/// 
+/// Reply: A normal response
+/// Ping: is normally used for heartbeats
+/// Pong: is normally used for responding to heartbeats
+/// Close: is used to close the connection
+/// 
+/// The inner string of the types is the message that the client socket will receive
+pub type Frame {
+  Reply(String)
+  Ping(String)
+  Pong(String)
+  Close(String)
+}
+
+/// Websocket is a function that takes a string and returns a Frame
+/// 
+/// The string is the message that the client socket will receive
+/// and the Frame is the response that the server will send.
+pub type Websocket =
+  fn(String) -> Frame

--- a/src/gleam_websocket_native.erl
+++ b/src/gleam_websocket_native.erl
@@ -1,0 +1,30 @@
+% Originally from this stackoverflow post, modified to work with espresso gleam modules.
+% https://stackoverflow.com/questions/66682534/how-to-connect-cowboy-erlang-websocket-to-webflow-io-generated-webpage
+-module(gleam_websocket_native).
+-export([init/2, websocket_init/1, websocket_handle/2, websocket_info/2, module_name/0]).
+
+module_name() ->
+    ?MODULE.
+
+init(Req, Handler) ->
+    %Perform websocket setup
+    {cowboy_websocket, Req, Handler}.
+
+websocket_init(Handler) ->
+    {ok, Handler}.
+
+websocket_handle({text, Msg}, Handler) ->
+    case Handler(Msg) of
+        {reply, Value} -> {reply, {text, Value}, Handler};
+        {ping, Value} -> {reply, {pong, Value}, Handler};
+        {pong, Value} -> {reply, {ping, Value}, Handler};
+        {close, Value} -> {reply, {close, Value}, Handler}
+    end;
+%Ignore
+websocket_handle(_Other, State) ->
+    {ok, State}.
+
+websocket_info({text, Text}, State) ->
+    {reply, {text, Text}, State};
+websocket_info(_Other, State) ->
+    {ok, State}.


### PR DESCRIPTION
Lets you do something like this 

```gleam
 import espresso/router.{websocket}
 import espresso/websocket.{Websocket}

 pub fn main() {
  let router =
    router.new()
    |> websocket(
      "/socket",
      fn(frame) {
        case frame {
          "chat:" <> _message -> websocket.Reply("Hello")
          "ping" -> websocket.Reply("pong")
          "actual_ping" -> websocket.Ping("")
          "pong" -> websocket.Pong("")
          _ -> websocket.Close("")
        }
      },
    )

  start(router)
}
```